### PR TITLE
Remove code coverage from PhpSpec configuration

### DIFF
--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,15 +1,7 @@
 extensions:
   - MageTest\PhpSpec\MagentoExtension\Extension
-  - PhpSpec\Extension\CodeCoverageExtension
 mage_locator:
   spec_prefix: 'spec'
   src_path: 'public/app/code'
   spec_path: 'spec/public/app/code'
-code_coverage:
-  whitelist:
-    - "public/app/code/local"
-  output: "build/coverage/clover.xml"
-  format: "clover"
-  show_uncovered_files: true
-  lower_upper_bound: 100
-  high_lower_bound: 100
+


### PR DESCRIPTION
PhpSpec is a BDD framework. If you were doing BDD you would describe the behaviour of your class prior to writing your class. If you did that way the relevant behaviour of your classes would all be properly covered with "tests".

Code coverage tools and metrics are useful for legacy code (code you wrote without specs/tests). You can use a tool like that to try and get up to a point where you can continue TDD and have the benefit of being protected from regression.

In general that approach isn't really as effective as describing the behaviour first (TDD). A single method may be simple enough to respond to more than one required behaviour. You know that when you are TDDing, you keep refactoring in the process, deleting unneeded code. You end up with 10 specs (tests) hitting the same lines of code, all describing different needed behaviour, all useful to understand the code.

One of the problems with the word "test" is that it makes people think TDD is about verification. It's not. It's about communication. StoryBDD is communication between stakeholders and SpecBDD is communication between classes. Simple, living, just enough documentation.

Code coverage done to guarantee you have tested your code is a fallacy, a poor metric at best. Unfortunately people think testing structure is more important than testing behaviours. That's why BDD was born, to help bring the focus back on the right track. Making sure this part of the code is tested is fake because that part of the code can do more than one thing, it should, if it's nicely refactored. Also you will end up testing stuff like accessors and modifiers and constructors, etc.
