### PR TITLE
TMUP-276: Add Magento role to tune MySQL replicas

### DIFF
--- a/tools/chef/roles/magento.json
+++ b/tools/chef/roles/magento.json
@@ -1,0 +1,13 @@
+{
+  "name": "magento",
+  "chef_type": "role",
+  "json_class": "Chef::Role",
+  "description": "Magento role configuration",
+  "default_attributes": {
+    "mysql": {
+      "tunable": {
+        "binlog_format": "MIXED"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit should set the MySQL's `binlog_format` to `MIXED` as now is being set to `STATEMENT`.
