### PR TITLE
Remove unnecessarily restrictive versioning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,8 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpspec/phpspec": "dev-master#3bcf4e4ec83dc345d0fff7f22b0641a25403dcc9",
-        "phpspec/prophecy": "dev-master#82d11835df7eccf904ea0c84fbb7304080346bc1",
         "magetest/magento-phpspec-extension": "dev-develop",
         "magetest/magento-behat-extension": "dev-feature/refactor",
-        "behat/behat": "2.4.*@stable",
         "behat/mink-selenium2-driver": "*",
         "behat/mink-goutte-driver": "1.0.*",
         "squizlabs/php_codesniffer": "1.*",


### PR DESCRIPTION
Phpspec/prophecy and behat are installed as dependencies of their respective extensions, having them in specific versions causes conflicts with packages that require more up-to-date versions of their components.