### PR TITLE
Add src/ to autoload for non-Magento custom code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
                 "public/app/code/community",
                 "public/app/code/core",
                 "public/app",
-                "public/lib"
+                "public/lib",
+                "src"
             ],
             "Mage" : "public/app/code/core"
         }


### PR DESCRIPTION
Required if we're creating custom code that is not Magento-specific, but not [yet] shareable on other projects.