### PR TITLE
Set hostname to the config.hostname value to avoid a redirect

### DIFF
--- a/docker-compose.yml.erb
+++ b/docker-compose.yml.erb
@@ -30,7 +30,7 @@ services:
       TIDEWAYS_ENABLED: 'true'
       RUN_BUILD: # get from host env
       WEB_DIRECTORY: public
-      WEB_HOST: localhost
+      WEB_HOST: <%= config.hostname %>
       AUTH_HTTP_HEALTHCHECK_LOCATION: '/status/healthcheck'
     healthcheck:
       test: ["CMD", "curl", "--fail", "--header", "--insecure", "https://localhost/status/healthcheck"]


### PR DESCRIPTION
As magento tries to enforce the URL configured in web/secure/base_url by default, the docker setup is redirecting to https://localhost/

To avoid this, set the hostname as `WEB_HOST`